### PR TITLE
Prepare the native Linux 64-bit release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@
 
 > [!IMPORTANT]
 > 🌙 The authored reconstruction is complete, and native Linux play now covers
-> both i386 and x86_64. Active ELF64 work and downloadable CI artifacts live on
-> [`port/portable-64bit`](https://github.com/N0zoM1z0/th08/tree/port/portable-64bit);
+> both i386 and x86_64. Download the
+> [latest native Linux release](https://github.com/N0zoM1z0/th08/releases/latest);
+> active ELF64 source lives on
+> [`port/portable-64bit`](https://github.com/N0zoM1z0/th08/tree/port/portable-64bit).
 > Windows and macOS ports are still in progress.
 
 ## Repository status
@@ -104,6 +106,7 @@ usually slower.
 
 **Status: Playable**
 
+- [Download the latest native Linux release](https://github.com/N0zoM1z0/th08/releases/latest)
 - [Download, installation, and player guide](docs/PLAY_LINUX.md)
 - [Native Linux porting architecture and validation](docs/LINUX_PORTING.md)
 - [Native 64-bit build and validation](docs/PORTABLE_64BIT.md)
@@ -122,8 +125,8 @@ After first-time setup, use the incremental launcher:
 scripts/play-modern-linux.sh "/path/to/the/original/TH08 directory"
 ```
 
-The CI workflow publishes i386, x86_64, and AArch64 portable Actions artifacts.
-The 64-bit artifacts are currently built from
+Release assets and the CI workflow provide i386, x86_64, and AArch64 portable
+packages. The 64-bit packages are built from
 [`port/portable-64bit`](https://github.com/N0zoM1z0/th08/tree/port/portable-64bit).
 Extract the package for your architecture and pass the original data directory:
 

--- a/docs/PLAY_LINUX.md
+++ b/docs/PLAY_LINUX.md
@@ -7,7 +7,7 @@ Docker, and the original `th08.exe` are not runtime requirements.
 
 ## What you need
 
-- an x86 or x86-64 Linux desktop with working OpenGL and audio;
+- a Linux desktop with working OpenGL and audio;
 - the runtime packages listed below;
 - a legally obtained original Japanese TH08 1.00d data directory containing:
   - `th08.dat`
@@ -20,24 +20,33 @@ backups, and diagnostic logs there.
 
 ## 1. Download the portable release
 
-Open the [TH08 releases page](https://github.com/N0zoM1z0/th08/releases) and
-download both Linux assets from the newest Linux Preview release:
+Open the [latest TH08 release](https://github.com/N0zoM1z0/th08/releases/latest)
+and download the archive and matching `.sha256` file for your architecture:
 
-- `th08-modern-linux-i386.tar.gz`
-- `th08-modern-linux-i386.tar.gz.sha256`
+| Host | Status | Archive |
+| --- | --- | --- |
+| x86_64 / AMD64 | **Recommended; full-route tested** | `th08-portable-linux-x86_64.tar.gz` |
+| i386 / 32-bit x86 | Compatibility build | `th08-modern-linux-i386.tar.gz` |
+| AArch64 / ARM64 | **Experimental; real-hardware gameplay not yet verified** | `th08-portable-linux-aarch64.tar.gz` |
 
-The GitHub Actions artifact is useful for development snapshots, but the
-Release assets are the stable download entry point for players.
+Most Intel and AMD Linux computers should use the x86_64 package. Check an
+unfamiliar machine with `uname -m`; it normally prints `x86_64`, `i686`, or
+`aarch64`. GitHub Actions artifacts are development snapshots, while Release
+assets are the stable player download.
 
-Native x86_64 and AArch64 snapshots currently live on
-[`port/portable-64bit`](https://github.com/N0zoM1z0/th08/tree/port/portable-64bit).
-Open that branch's
-[Portable Linux workflow](https://github.com/N0zoM1z0/th08/actions/workflows/portable-linux.yml?query=branch%3Aport%2Fportable-64bit),
-select a successful run, and download the artifact matching your architecture.
+## 2. Install the runtime libraries
 
-## 2. Install the 32-bit runtime libraries
+On an x86_64 Debian, Ubuntu, Kali Linux, or compatible system, install:
 
-On Debian, Ubuntu, Kali Linux, or a compatible derivative running on x86-64:
+```bash
+sudo apt-get update
+sudo apt-get install \
+  libstdc++6 libgl1 libfontconfig1 \
+  libsdl2-2.0-0 libsdl2-image-2.0-0 libsdl2-ttf-2.0-0 \
+  fonts-vlgothic
+```
+
+The i386 compatibility package needs the corresponding 32-bit libraries:
 
 ```bash
 sudo dpkg --add-architecture i386
@@ -48,21 +57,24 @@ sudo apt-get install \
   fonts-vlgothic
 ```
 
-Other distributions need equivalent i386 packages for the C++ runtime,
-OpenGL, Fontconfig, SDL2, SDL2_image, and SDL2_ttf, plus a Japanese font. The
-launcher itself never invokes `sudo`.
+On a native AArch64 Debian-family system, install the same unqualified package
+names as x86_64. Other distributions need equivalent native packages for the
+C++ runtime, OpenGL, Fontconfig, SDL2, SDL2_image, and SDL2_ttf, plus a Japanese
+font. The launcher itself never invokes `sudo`.
 
 ## 3. Verify and extract the package
 
-Run these commands in the directory containing the two downloaded files:
+For the recommended x86_64 package, run these commands in the directory
+containing the two downloaded files:
 
 ```bash
-sha256sum -c th08-modern-linux-i386.tar.gz.sha256
-tar -xzf th08-modern-linux-i386.tar.gz
-cd th08-modern-linux-i386
+sha256sum -c th08-portable-linux-x86_64.tar.gz.sha256
+tar -xzf th08-portable-linux-x86_64.tar.gz
+cd th08-portable-linux-x86_64
 ```
 
-Do not continue if the checksum command reports a mismatch.
+For i386 or AArch64, substitute the exact archive and checksum names from the
+table above. Do not continue if the checksum command reports a mismatch.
 
 ## 4. Start TH08
 
@@ -78,7 +90,7 @@ For example, if the extracted package is a child of the data directory:
 TH08/
 ├── th08.dat
 ├── thbgm.dat
-└── th08-modern-linux-i386/
+└── th08-portable-linux-x86_64/
 ```
 
 start it from inside the package with:

--- a/docs/PORTABLE_64BIT.md
+++ b/docs/PORTABLE_64BIT.md
@@ -5,7 +5,9 @@ fixed-layout i386 port. Both products compile the reconstructed authored game
 sources and use the repository SDL2/OpenGL backend. Neither product executes
 or bundles the original `th08.exe`.
 
-Active development and CI artifacts are on
+Stable packages are available from the
+[latest TH08 release](https://github.com/N0zoM1z0/th08/releases/latest).
+Active development and CI snapshots remain on
 [`port/portable-64bit`](https://github.com/N0zoM1z0/th08/tree/port/portable-64bit).
 The default branch links here so users do not have to discover the port among
 the repository's other development branches.

--- a/docs/RE_HANDOFF.md
+++ b/docs/RE_HANDOFF.md
@@ -6,8 +6,9 @@ come from the ledgers, not this prose.
 
 ## Portable x86_64 score compatibility checkpoint
 
-The `fix/portable64-enemy-render-oracle` follow-up to
-`port/portable-64bit` now keeps the `score.dat` wire header at its original
+The completed `fix/portable64-enemy-render-oracle` follow-up was merged into
+`port/portable-64bit` through PR #5 and its short-lived branch was retired. It
+keeps the `score.dat` wire header at its original
 `0x1c` bytes while placing the live native `ScoreListNode *` after that fixed
 header.  The affected authored functions are
 `ResultScreen::WriteScore @ 0x00453D0D` and the ScoreDat family at
@@ -34,11 +35,12 @@ passed **43 / 43**, including `WriteScore` at **1,372 / 1,372 bytes**.  The fina
 single-job non-reuse cold replay passed **1,106 / 1,106 exact** accepted units
 with no failures.  No authored or exact ledger totals changed.
 
-## Active semantic reconstruction branch
+## Completed semantic reconstruction branch
 
-`semantic/typed-reconstruction` starts from `main@4cffb2a` and makes semantic
-source recovery the active bounded lane.  The bootstrap scope changes no game
-layout, function mapping, authored ledger, or accepted exact unit.  It adds the
+The former `semantic/typed-reconstruction` lane started from `main@4cffb2a`,
+completed its authored readability audit, and was merged into `main` through
+PR #4. Its remote branch has been retired. The bootstrap scope changed no game
+layout, function mapping, authored ledger, or accepted exact unit. It added the
 evidence/acceptance guide in `docs/SEMANTIC_RECONSTRUCTION.md`, the
 `$th08-semantic` workflow, and the read-only
 `scripts/analysis/report-semantic-debt.py` candidate router.

--- a/docs/RE_WORKFLOW.md
+++ b/docs/RE_WORKFLOW.md
@@ -124,9 +124,10 @@ remain available for later diagnosis in `config/match-units.toml`; see
 `docs/RE_HANDOFF.md` for the bounded list. Do not treat a configured unit as an
 accepted result.
 
-The active lane on `semantic/typed-reconstruction` is semantic source recovery.
-Replace raw object offsets, anonymous fields, and absolute field views one
-coherent structure family at a time, following
+The semantic source-recovery phase formerly carried on
+`semantic/typed-reconstruction` is complete and was merged into `main` through
+PR #4; that remote branch has been retired. Start any newly bounded semantic
+maintenance from current `main` on a fresh short-lived branch and follow
 `docs/SEMANTIC_RECONSTRUCTION.md`. Existing accepted VC7 units are the binary
 oracle; the modern Windows/Linux source products are the portability and
 behavior oracle. Candidate counts from


### PR DESCRIPTION
## Summary

- make x86_64 the recommended Linux player download
- document i386 as the compatibility package and AArch64 as experimental
- add architecture-specific dependencies, checksums, extraction, and launch commands
- retire stale references to completed temporary branches

## Release target

- tag: `v0.2.0-linux-64bit`
- title: `TH08 Reconstruction v0.2.0 — Native Linux 64-bit`

## Validation

- canonical target: SHA-256 `330fbdbf58a710829d65277b4f312cfbb38d5448b3df523e79350b879213d924`, 840704 bytes
- non-reuse cold exact replay: `1106 / 1106` accepted units
- `python3 scripts/ci.py`
- `git diff --check`